### PR TITLE
Changing style for img to be responsive to screen size

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,7 @@
 <body style="margin: 0px; background: #0e0e0e; height: 100%">
 {% block content %}
     <a href="?artist={{ artist }}">
-        <img src="{{ uri }}"
-             style="background-color: hsl(0, 0%, 90%);transition: background-color 300ms"
-             width="650"
-             height="650">
+        <img src="{{ uri }}" style="width: 100%; height: auto;">
     </a>
 {% endblock %}
 </body>


### PR DESCRIPTION
To maximize visual joy maximize the cover artwork on device/screen size:
<img width="298" alt="Screenshot 2022-12-25 at 08 27 56" src="https://user-images.githubusercontent.com/209369/209460279-ac4d725c-b45d-4419-a3d0-d7272e06d070.png">
