### PR TITLE
fixar storleksproblem

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -52,8 +52,12 @@
     </style>
 
     {% block content %}
-    <div class="container square content">
-        <a href="?artist={{ artist }}"><img src="{{ uri }}"> </a>
+    <div class="container">
+        <div class="square">
+            <div class="content">
+                <a href="?artist={{ artist }}"><img src="{{ uri }}"> </a>
+            </div>
+        </div>
     </div>
     {% endblock %}
 


### PR DESCRIPTION
Div-change resulted in this altering size stuff:
<img width="1439" alt="Screenshot 2022-12-27 at 21 43 37" src="https://user-images.githubusercontent.com/209369/209720572-d81ea473-ef55-42de-a65d-0dcdabba23c4.png">
<img width="1439" alt="Screenshot 2022-12-27 at 21 43 32" src="https://user-images.githubusercontent.com/209369/209720579-ab844e14-7b6d-442c-ba42-5e31c035a274.png">
<img width="1439" alt="Screenshot 2022-12-27 at 21 43 23" src="https://user-images.githubusercontent.com/209369/209720585-b07f1cf3-137e-4830-a4b0-0b74f6170f78.png">


After doing this revert, the big size, same size look & feel is back:
<img width="1439" alt="Screenshot 2022-12-27 at 21 37 25" src="https://user-images.githubusercontent.com/209369/209720818-8377fe47-6dba-4dcb-ba56-ef8c23f0c98b.png">
<img width="1439" alt="Screenshot 2022-12-27 at 21 37 43" src="https://user-images.githubusercontent.com/209369/209720681-da801b1c-f054-4593-a28f-d78923471a37.png">
<img width="1439" alt="Screenshot 2022-12-27 at 21 37 08" src="https://user-images.githubusercontent.com/209369/209720877-4070e02e-c3ba-425b-8180-38477c602702.png">
